### PR TITLE
Clarify RTRQ invalidation topics and protect shared secrets

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -9,6 +9,8 @@ Recommended Codex app wiring:
 - Setup script: `.codex/scripts/bootstrap.sh`
 - Action `Validate`: `.codex/scripts/validate.sh`
 - Action `Typecheck`: `.codex/scripts/typecheck.sh`
+- Action `Python lint`: `.codex/scripts/python-lint.sh`
+- Action `Python typecheck`: `.codex/scripts/python-typecheck.sh`
 - Action `Python tests`: `.codex/scripts/python-tests.sh`
 - Action `Run server`: `.codex/scripts/run-server.sh`
 - Action `Build`: `.codex/scripts/build.sh`
@@ -18,6 +20,7 @@ What these scripts guarantee:
 - Fail fast if `bun` or `uv` is missing.
 - Bootstrap both the Bun and `uv` workspaces for fresh worktrees.
 - Keep validation aligned with the repo's canonical package-manager flows.
+- Keep the aggregate validation path aligned with `VALIDATION.md`.
 
 Relevant Codex docs:
 

--- a/.codex/scripts/bootstrap.sh
+++ b/.codex/scripts/bootstrap.sh
@@ -15,5 +15,5 @@ fi
 
 cd "${ROOT_DIR}"
 
-bun install
+bun install --frozen-lockfile
 uv sync --project "${ROOT_DIR}" --all-packages --all-groups

--- a/.codex/scripts/python-lint.sh
+++ b/.codex/scripts/python-lint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv is required for Python lint validation." >&2
+  exit 1
+fi
+
+cd "${ROOT_DIR}"
+
+uv run --project "${ROOT_DIR}" --package rtrq-server ruff check "${ROOT_DIR}/apps/server"
+uv run --project "${ROOT_DIR}" --package rtrq-server-sdk ruff check "${ROOT_DIR}/packages/server-sdks/python"

--- a/.codex/scripts/python-typecheck.sh
+++ b/.codex/scripts/python-typecheck.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv is required for Python type validation." >&2
+  exit 1
+fi
+
+cd "${ROOT_DIR}"
+
+uv run --project "${ROOT_DIR}" --package rtrq-server ty check "${ROOT_DIR}/apps/server/src" "${ROOT_DIR}/apps/server/tests"
+uv run --project "${ROOT_DIR}" --package rtrq-server-sdk ty check "${ROOT_DIR}/packages/server-sdks/python/src" "${ROOT_DIR}/packages/server-sdks/python/tests"

--- a/.codex/scripts/typecheck.sh
+++ b/.codex/scripts/typecheck.sh
@@ -10,4 +10,9 @@ fi
 
 cd "${ROOT_DIR}"
 
+if [[ ! -x "${ROOT_DIR}/node_modules/.bin/tsc" ]]; then
+  echo "TypeScript dependencies are not installed. Run 'bun run bootstrap' first." >&2
+  exit 1
+fi
+
 bun run typecheck

--- a/.codex/scripts/validate.sh
+++ b/.codex/scripts/validate.sh
@@ -3,7 +3,14 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv is required for repository validation." >&2
+  exit 1
+fi
+
 "${ROOT_DIR}/.codex/scripts/typecheck.sh"
+"${ROOT_DIR}/.codex/scripts/python-lint.sh"
+"${ROOT_DIR}/.codex/scripts/python-typecheck.sh"
 "${ROOT_DIR}/.codex/scripts/python-tests.sh"
 
 uv run --project "${ROOT_DIR}" --package rtrq-server python -c "from rtrq_server.app import create_app; app = create_app(); print(app.title)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,39 @@
 - Prefer `rg` for repo search.
 - Respect existing package boundaries. Prefer small, contract-driven changes over broad reshuffles.
 
+## Source Of Record Boundary
+
+- Linear is the system of record for steering truth: prioritization, ownership, sequencing, status, current execution plans, blockers, and ongoing coordination.
+- The repository is the system of record for execution truth: architecture, contracts, invariants, runbooks, validation flows, and technical decisions that agents need in order to change code correctly.
+- Never keep core technical contracts or architecture only in Linear.
+- Never keep backlog, ownership, or status tracking only in the repository.
+
+### Placement Rubric
+
+For any new artifact, answer these yes/no questions:
+
+1. Does this describe how RTRQ works, what it guarantees, or what interfaces or contracts it exposes?
+2. Would an agent be more likely to make a wrong code change if this artifact were unavailable during execution?
+3. Should this artifact be reviewed, versioned, and changed alongside code in the same PR?
+4. Is this intended to remain true across multiple tasks rather than only for the current work item?
+5. Does this define an invariant, boundary, runbook, or technical decision that future work should rely on?
+6. Is this primarily about prioritization, ownership, sequencing, status, or open coordination?
+7. Is this primarily provisional, exploratory, or tied to the current work item rather than the long-term system?
+
+Apply the rubric as follows:
+
+- If questions 1 through 5 are mostly `yes`, and questions 6 and 7 are mostly `no`, put it in the repository.
+- If questions 6 or 7 are `yes`, and questions 1 through 5 are mostly `no`, put it in Linear.
+- If both sides have strong `yes` answers, split it:
+  - Repository: durable technical truth.
+  - Linear: active plan, ownership, status, and discussion.
+- If the answer is still unclear, ask the user before writing it.
+
+### Escalation Rule
+
+- Ask the user when an artifact mixes durable technical guidance with active planning, introduces a new artifact category, records an unresolved decision that may become a technical rule, or is likely to drift if duplicated between Linear and the repository.
+- When unsure, ask a short question in this shape: `This artifact looks mixed: part durable technical truth, part active planning context. Should I split it between the repo and Linear, or keep it entirely in one place?`
+
 ## Workflow Expectations
 
 - Prefer test-driven development for new work when practical: add or update tests first, implement against them, then rerun the relevant scope.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 - Product and architecture source of truth: `RTRQ.md`.
 - Workspace layout, package locations, and top-level scripts: `README.md`.
+- Invariant source of truth: `INVARIANTS.md`.
+- Validation source of truth: `VALIDATION.md`.
 - Package manifests and existing source files define the executable contract when docs and code diverge.
 - Nested `AGENTS.md` files override this file for their subtree. Today that mainly applies to `apps/server/`.
 

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -19,15 +19,15 @@ These invariants are the human-readable source material for future tests, schema
 - Broad invalidation is represented by shorter logical key prefixes and their corresponding canonical topic strings.
 - The HTTP invalidation contract must stay aligned between the FastAPI server and active server SDKs.
 - Accepted HTTP invalidation requests return `200 OK`. This confirms request acceptance only, not client delivery.
-- The WebSocket protocol is limited to the documented MVP message taxonomy unless the protocol is intentionally revised:
+- Once the WebSocket transport in `apps/server` is wired, the WebSocket protocol is limited to the documented MVP message taxonomy unless the protocol is intentionally revised:
   - client to server: `subscribe`, `unsubscribe`
   - server to client: `ready`, `subscription_ack`, `invalidation`, `error`
-- `invalidation` messages carry `topics: string[]`, not a single scalar topic.
-- `subscription_ack.topic_count` is the number of unique validated topics in the accepted request payload. It is not the number of server-side state changes.
-- Each client subscription mutation receives exactly one terminal response from the server:
+- Once that transport is wired, `invalidation` messages carry `topics: string[]`, not a single scalar topic.
+- Once that transport is wired, `subscription_ack.topic_count` is the number of unique validated topics in the accepted request payload. It is not the number of server-side state changes.
+- Once that transport is wired, each client subscription mutation receives exactly one terminal response from the server:
   - `subscription_ack` if accepted
   - `error` if invalid or rejected
-- RTRQ does not send both `subscription_ack` and `error` for the same `op_id`.
+- Once that transport is wired, RTRQ does not send both `subscription_ack` and `error` for the same `op_id`.
 
 ## Responsibility Invariants
 

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -1,0 +1,63 @@
+# RTRQ Invariants
+
+This document records the durable technical invariants that future changes must preserve unless the product architecture is intentionally revised.
+
+These invariants are the human-readable source material for future tests, schema checks, and structural enforcement. They are not task plans or implementation notes.
+
+## Contract Invariants
+
+- Cross-process protocol identity is a canonical topic string, not a raw library-owned query-key object.
+- A topic string is the canonical JSON serialization of a logical query-key array.
+- The logical query-key grammar for the MVP is constrained:
+  - the top-level value is an array
+  - array elements and nested values are valid JSON values only
+  - object keys are strings
+  - arrays preserve order
+  - values outside the JSON data model are not transportable
+- Object segments are treated as unordered maps for protocol identity. Logically equivalent objects must canonicalize to the same topic string regardless of source key order.
+- Cross-process boundaries use topic strings. Structured logical keys may exist inside adapters, but they are not the transport identity.
+- Broad invalidation is represented by shorter logical key prefixes and their corresponding canonical topic strings.
+- The HTTP invalidation contract must stay aligned between the FastAPI server and active server SDKs.
+- Accepted HTTP invalidation requests return `200 OK`. This confirms request acceptance only, not client delivery.
+- The WebSocket protocol is limited to the documented MVP message taxonomy unless the protocol is intentionally revised:
+  - client to server: `subscribe`, `unsubscribe`
+  - server to client: `ready`, `subscription_ack`, `invalidation`, `error`
+- `invalidation` messages carry `topics: string[]`, not a single scalar topic.
+- `subscription_ack.topic_count` is the number of unique validated topics in the accepted request payload. It is not the number of server-side state changes.
+- Each client subscription mutation receives exactly one terminal response from the server:
+  - `subscription_ack` if accepted
+  - `error` if invalid or rejected
+- RTRQ does not send both `subscription_ack` and `error` for the same `op_id`.
+
+## Responsibility Invariants
+
+- The RTRQ server performs exact string matching only for topic delivery. It does not implement library-specific fuzzy or hierarchical query matching.
+- Canonicalization happens before topic identity is used for matching, subscription, or invalidation fan-out.
+- The server owns HTTP invalidation ingress and WebSocket delivery, not client-library query semantics.
+- The core client owns WebSocket connection lifecycle and subscription transport behavior.
+- Client subscription mutations are carried over the authenticated WebSocket connection in the MVP. RTRQ does not expose a separate browser HTTP API for subscribe or unsubscribe.
+- The React Query adapter owns derivation of topic subscriptions from cached query usage.
+- The React Query adapter owns translation from received topic strings back into library-native `invalidateQueries` calls.
+- Server-side subscription state is connection-scoped, not user-scoped.
+- Server-side subscription state behaves as a set:
+  - subscribing to an already-present topic is a no-op
+  - unsubscribing from an absent topic is a no-op
+  - duplicate topics in a single mutation do not create multiple entries
+- The MVP authenticates browser connections but does not enforce fine-grained authorization for individual topic subscriptions.
+
+## Failure-Mode Invariants
+
+- RTRQ preserves the product goal of degraded speed, not broken functionality. If RTRQ is unavailable, application fetch and refetch behavior must remain correct without RTRQ-specific recovery logic.
+- At-least-once invalidation signaling is acceptable. Duplicate invalidation delivery is expected to be safe and idempotent on the client side.
+- If a query key cannot be canonicalized into a topic string, adapters must fail safe by preserving local library behavior without RTRQ transport for that key.
+- RTRQ does not guarantee replay of missed invalidations in the MVP.
+- Invalidation delivery may race with subscription mutations or disconnects. Missed invalidations in those windows are tolerated in the MVP.
+- Subscription state is not durable across disconnects. Reconnect requires the client to replay its current subscription set.
+- Authentication failure for browser connections is handled at handshake or connection level, not as a normal post-auth application message in the MVP.
+- Invalid subscription mutation messages fail as whole operations. The MVP does not use partial-success responses for malformed or mixed-validity subscription payloads.
+
+## Scope Notes
+
+- These invariants apply to active surfaces only: `apps/server`, `packages/server-sdks/python`, `packages/clients/core`, and `packages/clients/adapters/react-query`.
+- Placeholder packages do not expand the protocol or architecture by implication.
+- If a future change intentionally breaks one of these invariants, the invariant must be updated in the same change that revises the contract.

--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ This repository contains the initial monorepo skeleton for RTRQ using Bun for th
 
 - Redis wiring is intentionally not provisioned in this repository.
 - The code included here is scaffolding only. It defines package boundaries, public APIs, and build surfaces without implementing the full invalidation pipeline yet.
-- Python packages are managed as a `uv` workspace rooted at [pyproject.toml](/Users/baedin/Documents/projects/rtrq/pyproject.toml).
+- Python packages are managed as a `uv` workspace rooted at [pyproject.toml](./pyproject.toml).

--- a/README.md
+++ b/README.md
@@ -26,11 +26,16 @@ This repository contains the initial monorepo skeleton for RTRQ using Bun for th
 
 ## Scripts
 
+- `bun run bootstrap` prepares a fresh worktree for active development and validation.
+- `bun run validate` runs the default aggregate validation flow for the active repository surfaces.
 - `bun install` installs the TypeScript workspace dependencies.
 - `bun run lock:py` refreshes the Python `uv.lock` file.
+- `bun run lint:py` runs Ruff for the active Python packages.
 - `bun run setup:py` syncs the Python workspace into the repo-local `.venv/` via `uv`.
 - `bun run build` builds the TypeScript packages and Python distributions.
 - `bun run typecheck` runs TypeScript typechecking for the Bun workspace packages.
+- `bun run typecheck:py` runs Python typechecking for the active Python packages via `ty`.
+- `bun run python-tests` runs Python tests for the active Python packages.
 - `bun run dev:server` boots the FastAPI app in reload mode through `uv run`.
 
 ## Notes

--- a/RTRQ.md
+++ b/RTRQ.md
@@ -59,17 +59,50 @@ Built with **FastAPI**, the server handles two distinct roles in a single proces
 ### Invalidation Flow
 
 1. A mutation completes on the application server.
-2. The application server calls the RTRQ Server's HTTP endpoint via the Server SDK, passing the query key(s) to invalidate and a shared secret credential.
+2. The application server calls the RTRQ Server's HTTP endpoint via the Server SDK, passing the topic key(s) to invalidate and a shared secret credential.
 3. The RTRQ Server publishes the invalidation event to Redis.
-4. All WebSocket nodes subscribed to Redis receive the event and identify connected clients whose subscription set intersects with the invalidated keys.
-5. Matching clients receive a WebSocket message and their local Client SDK calls `invalidateQueries` with the received key(s).
+4. All WebSocket nodes subscribed to Redis receive the event and identify connected clients whose subscription set intersects with the invalidated topic keys.
+5. Matching clients receive a WebSocket message and their local Client SDK calls `invalidateQueries` with the received logical key prefix.
 6. React Query (or the equivalent library) executes its standard refetch logic.
 
 ### Query Key Semantics
 
-Query key matching is intentionally kept **server-side dumb**. The RTRQ server treats keys as opaque strings and performs exact matching only. Hierarchical/fuzzy matching (e.g., invalidating `['todos']` to match `['todos', userId, { filter: 'active' }]`) is the responsibility of the **receiving client**, which delegates directly to React Query's native `invalidateQueries` matching logic. This keeps the server free of library-specific semantics and ensures matching behavior is always consistent with the version of React Query the client is running.
+Query key matching is intentionally kept **server-side dumb**. The RTRQ server treats keys as opaque strings and performs exact matching only. Hierarchical/fuzzy matching (e.g., invalidating `['todos']` to match `['todos', { "userId": "123", "filter": "active" }]`) is the responsibility of the **receiving client**, which delegates directly to React Query's native `invalidateQueries` matching logic. This keeps the server free of library-specific semantics and ensures matching behavior is always consistent with the version of React Query the client is running.
 
-Application servers should therefore broadcast keys at the appropriate level of specificity. If broad invalidation is needed, the Server SDK should emit a key pattern that the client adapters are configured to handle.
+RTRQ's cross-process protocol uses **topic keys**, not raw library-owned query-key objects. A topic key is the canonical JSON serialization of a logical query-key array. The serialized JSON string is the protocol identity used for exact matching, subscriptions, and invalidation fan-out.
+
+The MVP logical query-key grammar is intentionally constrained:
+
+- The top-level value must be a JSON array.
+- Each array element must be either a string or a plain JSON object.
+- Object values may be JSON primitives only: string, number, boolean, or null.
+- Nested arrays and nested objects are not part of the MVP protocol.
+
+Object segments are treated as unordered maps for protocol purposes. Producers must sort object keys recursively before serialization so that logically equivalent keys produce the same topic key string. For example, `["todos", {"filter":"active","userId":"123"}]` and `["todos", {"userId":"123","filter":"active"}]` must serialize to the same topic key string.
+
+Broad invalidation is represented by shorter logical key prefixes. For example, invalidating `["todos"]` should trigger library-native matching on clients that hold more specific keys such as `["todos", {"userId":"123"}]`.
+
+Application servers should therefore broadcast topic keys at the appropriate level of specificity. If broad invalidation is needed, the Server SDK should emit the canonical topic key for the desired prefix.
+
+### WebSocket Subscription Semantics
+
+Client subscriptions are maintained over the existing WebSocket connection. RTRQ does not use a separate HTTP surface for browser subscription management in the MVP.
+
+Each WebSocket connection owns a server-side subscription set:
+
+- The subscription set starts empty when the connection is established.
+- Clients mutate that set by sending add and remove messages over the socket.
+- Add and remove operations may contain one topic key or many topic keys.
+- Add and remove operations are idempotent.
+- Subscription state is connection-scoped, not user-scoped.
+
+The core client owns the WebSocket transport and subscription lifecycle. The React Query adapter is responsible for deriving topic subscriptions from active query usage and replaying the current subscription set after reconnect.
+
+RTRQ does not durably store subscription state across disconnects. After reconnect, the client must rehydrate the server-side subscription set by replaying its current topics as add messages.
+
+The server acknowledges subscription mutations over the WebSocket connection. An acknowledgement confirms that the mutation was accepted and applied to the connection's subscription set. It does not guarantee future invalidation delivery.
+
+Invalidation delivery may race with subscription changes or disconnects. The MVP intentionally tolerates missed invalidations in those windows under the "degraded speed, not broken functionality" design goal. Replay of missed invalidations is out of scope for the MVP.
 
 ---
 
@@ -102,7 +135,7 @@ A framework-agnostic TypeScript library responsible for:
 
 - Managing the WebSocket connection lifecycle (connect, reconnect, backoff).
 - Authenticating at handshake time using the provided session token.
-- Maintaining the client's subscription set.
+- Maintaining the client's connection-scoped subscription set.
 - Receiving invalidation messages and dispatching them to registered handlers.
 
 ### React Query Adapter (MVP)
@@ -111,8 +144,9 @@ The React Query adapter wraps the QueryClient via a `createQueryClient()` factor
 
 The adapter does two things:
 
-- **On invalidation send:** Intercepts outbound `invalidateQueries` calls (via a proxied QueryClient or a global `MutationCache` `onSuccess` callback) and forwards them to the RTRQ Server, so that mutations by Client A are broadcast to Clients B and C.
-- **On invalidation receive:** Listens to the Core Client SDK and calls the underlying QueryClient's `invalidateQueries` when a message is received, triggering React Query's native refetch flow.
+- **On subscription maintenance:** Derives canonical topic keys from active query usage and keeps the Core Client SDK's connection-scoped subscription set in sync.
+- **On invalidation send:** Intercepts outbound `invalidateQueries` calls (via a proxied QueryClient or a global `MutationCache` `onSuccess` callback), derives the canonical topic key prefix to invalidate, and forwards it to the RTRQ Server so that mutations by Client A are broadcast to Clients B and C.
+- **On invalidation receive:** Listens to the Core Client SDK, deserializes the canonical topic key back into the constrained logical query-key shape, and calls the underlying QueryClient's `invalidateQueries` when a message is received, triggering React Query's native refetch flow.
 
 ---
 

--- a/RTRQ.md
+++ b/RTRQ.md
@@ -71,18 +71,31 @@ Query key matching is intentionally kept **server-side dumb**. The RTRQ server t
 
 RTRQ's cross-process protocol uses **topic keys**, not raw library-owned query-key objects. A topic key is the canonical JSON serialization of a logical query-key array. The serialized JSON string is the protocol identity used for exact matching, subscriptions, and invalidation fan-out.
 
-The MVP logical query-key grammar is intentionally constrained:
+The MVP logical query-key grammar follows the JSON data model:
 
 - The top-level value must be a JSON array.
-- Each array element must be either a string or a plain JSON object.
-- Object values may be JSON primitives only: string, number, boolean, or null.
-- Nested arrays and nested objects are not part of the MVP protocol.
+- Array elements and nested values may be any valid JSON value: string, number, boolean, null, array, or plain object.
+- Object keys must be strings.
+- Arrays preserve order for protocol identity.
+- Values outside the JSON data model are not part of the MVP protocol, including `undefined`, functions, symbols, `BigInt`, class instances, and non-finite numbers.
 
-Object segments are treated as unordered maps for protocol purposes. Producers must sort object keys recursively before serialization so that logically equivalent keys produce the same topic key string. For example, `["todos", {"filter":"active","userId":"123"}]` and `["todos", {"userId":"123","filter":"active"}]` must serialize to the same topic key string.
+Object segments are treated as unordered maps for protocol purposes. Producers must sort object keys recursively before serialization so that logically equivalent values produce the same topic key string. For example, `["todos", {"filter":"active","userId":"123"}]` and `["todos", {"userId":"123","filter":"active"}]` must serialize to the same topic key string.
 
 Broad invalidation is represented by shorter logical key prefixes. For example, invalidating `["todos"]` should trigger library-native matching on clients that hold more specific keys such as `["todos", {"userId":"123"}]`.
 
 Application servers should therefore broadcast topic keys at the appropriate level of specificity. If broad invalidation is needed, the Server SDK should emit the canonical topic key for the desired prefix.
+
+If a library-owned query key cannot be represented as a canonical topic key, the adapter must fail safe by preserving local library behavior without RTRQ transport for that key. Implementations may surface a development warning, but they must not break the application's existing fetch or refetch flow.
+
+### HTTP Invalidation Semantics
+
+The HTTP invalidation endpoint acknowledges accepted invalidation requests with `200 OK`. This response confirms that RTRQ accepted the request for processing. It does not guarantee delivery to any connected client.
+
+Recommended MVP error behavior:
+
+- `401 Unauthorized` when the shared-secret credential is missing or invalid
+- `422 Unprocessable Entity` when the payload is malformed
+- `413 Payload Too Large` when an operator-defined request size limit is exceeded
 
 ### WebSocket Subscription Semantics
 
@@ -96,13 +109,92 @@ Each WebSocket connection owns a server-side subscription set:
 - Add and remove operations are idempotent.
 - Subscription state is connection-scoped, not user-scoped.
 
-The core client owns the WebSocket transport and subscription lifecycle. The React Query adapter is responsible for deriving topic subscriptions from active query usage and replaying the current subscription set after reconnect.
+The core client owns the WebSocket transport and subscription lifecycle. The React Query adapter is responsible for deriving topic subscriptions from cached query usage and replaying the current subscription set after reconnect.
 
 RTRQ does not durably store subscription state across disconnects. After reconnect, the client must rehydrate the server-side subscription set by replaying its current topics as add messages.
 
 The server acknowledges subscription mutations over the WebSocket connection. An acknowledgement confirms that the mutation was accepted and applied to the connection's subscription set. It does not guarantee future invalidation delivery.
 
 Invalidation delivery may race with subscription changes or disconnects. The MVP intentionally tolerates missed invalidations in those windows under the "degraded speed, not broken functionality" design goal. Replay of missed invalidations is out of scope for the MVP.
+
+### WebSocket Message Taxonomy (MVP)
+
+The MVP WebSocket protocol uses a small typed message set. Each message includes a `type` field. Client mutation messages are correlated with an `op_id`. Server-delivered invalidation messages are correlated with a `delivery_id`.
+
+**Client to server messages**
+
+- `subscribe`
+  - Purpose: ensure one or more topic keys are present in the connection-scoped subscription set.
+  - Fields:
+    - `type: "subscribe"`
+    - `op_id: string`
+    - `topics: string[]`
+- `unsubscribe`
+  - Purpose: ensure one or more topic keys are absent from the connection-scoped subscription set.
+  - Fields:
+    - `type: "unsubscribe"`
+    - `op_id: string`
+    - `topics: string[]`
+
+Client subscription mutations are defined as idempotent set operations:
+
+- `subscribe(topics)` means "ensure these topics are present".
+- `unsubscribe(topics)` means "ensure these topics are absent".
+- Duplicate topics in a single message are ignored.
+- Subscribing to an already-subscribed topic is a no-op.
+- Unsubscribing from a missing topic is a no-op.
+- Empty `topics` arrays are invalid.
+
+**Server to client messages**
+
+- `ready`
+  - Purpose: confirm that the connection is authenticated and ready to accept subscription mutations.
+  - Fields:
+    - `type: "ready"`
+    - `connection_id: string`
+- `subscription_ack`
+  - Purpose: confirm that a `subscribe` or `unsubscribe` operation was accepted and applied.
+  - Fields:
+    - `type: "subscription_ack"`
+    - `op_id: string`
+    - `action: "subscribe" | "unsubscribe"`
+    - `topic_count: number`
+    - `result: "applied"`
+- `invalidation`
+  - Purpose: deliver one logical invalidation event to a client.
+  - Fields:
+    - `type: "invalidation"`
+    - `delivery_id: string`
+    - `topics: string[]`
+- `error`
+  - Purpose: report a protocol or validation error.
+  - Fields:
+    - `type: "error"`
+    - `op_id?: string`
+    - `code: string`
+    - `detail: string`
+
+For `subscription_ack`, `topic_count` is the number of unique validated topics in the accepted request payload. It is not the number of server-side state changes. This keeps acknowledgement semantics stable and auditable under retries and duplicate operations.
+
+Each client mutation receives exactly one terminal server response:
+
+- `subscription_ack` if the mutation is valid and accepted
+- `error` if the mutation is invalid or rejected
+
+RTRQ does not send both for the same `op_id`.
+
+An `invalidation` message may contain one topic key or many topic keys. The server may remove duplicate topics before delivery. Topic order within a single invalidation message is not semantically meaningful.
+
+Authentication failure is not modeled as a normal typed application message in the MVP. The connection should fail the handshake or close immediately if authentication does not succeed.
+
+The MVP intentionally omits:
+
+- client acknowledgement of invalidation delivery
+- subscription replacement or full server-side subscription snapshots
+- protocol-version negotiation
+- replay or resume cursors
+- partial-success subscription responses
+- delivery guarantees beyond at-least-once invalidation signaling
 
 ---
 
@@ -112,6 +204,8 @@ Two distinct credential types are used, reflecting the different trust levels of
 
 **Client authentication (browser → WebSocket):**
 Clients present their existing session token (JWT or equivalent) at WebSocket handshake time. The RTRQ Server validates this token using the same mechanism the application uses (shared secret validation, JWKS endpoint, etc.). This is configured once at server startup. Clients that fail validation are rejected at connection time.
+
+The MVP does not provide fine-grained, server-enforced authorization for individual topic subscriptions. Any authenticated client may request topic subscriptions within the deployment's existing trust boundary. Finer-grained subscription authorization is a future enhancement.
 
 **Server authentication (app server → HTTP endpoint):**
 Application servers include a shared secret (API key) in each HTTP request to the invalidation endpoint. This key is provisioned by the operator at deploy time and is never exposed to the browser. Network isolation provides defense-in-depth — the HTTP endpoint should be unreachable from public networks regardless of credential state.
@@ -144,7 +238,7 @@ The React Query adapter wraps the QueryClient via a `createQueryClient()` factor
 
 The adapter does two things:
 
-- **On subscription maintenance:** Derives canonical topic keys from active query usage and keeps the Core Client SDK's connection-scoped subscription set in sync.
+- **On subscription maintenance:** Derives canonical topic keys from cached query usage and keeps the Core Client SDK's connection-scoped subscription set in sync.
 - **On invalidation send:** Intercepts outbound `invalidateQueries` calls (via a proxied QueryClient or a global `MutationCache` `onSuccess` callback), derives the canonical topic key prefix to invalidate, and forwards it to the RTRQ Server so that mutations by Client A are broadcast to Clients B and C.
 - **On invalidation receive:** Listens to the Core Client SDK, deserializes the canonical topic key back into the constrained logical query-key shape, and calls the underlying QueryClient's `invalidateQueries` when a message is received, triggering React Query's native refetch flow.
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -1,0 +1,156 @@
+# RTRQ Validation Contract
+
+This document defines what repository-owned bootstrap and validation entrypoints must do for RTRQ.
+
+It is the durable source of truth for validation scope and expectations. Repo scripts, local environment actions, and future CI should be brought into alignment with this contract. If the current harness falls short, the harness is wrong, not the contract.
+
+## Goals
+
+- Give humans and agents one shared understanding of what "validated" means in this repository.
+- Keep validation aligned with RTRQ's active surfaces and documented protocol contract.
+- Prefer the smallest relevant validation during local development, with one higher-confidence aggregate validation entrypoint for broad checks.
+- Keep local validation and future CI behavior as close as practical.
+
+## Active Validation Scope
+
+This contract applies to the active surfaces only:
+
+- `apps/server`
+- `packages/server-sdks/python`
+- `packages/clients/core`
+- `packages/clients/adapters/react-query`
+
+Placeholder packages do not expand the default validation surface unless they become active work.
+
+## Canonical Entry Points
+
+The repository should expose these repo-owned entrypoints:
+
+- `bootstrap`
+  - Purpose: prepare a fresh worktree so active validation can run successfully.
+  - Current intended entrypoint: `.codex/scripts/bootstrap.sh`
+- `validate`
+  - Purpose: run the default high-confidence validation suite for the active repository surface.
+  - Current intended entrypoint: `.codex/scripts/validate.sh`
+- `typecheck`
+  - Purpose: run TypeScript type validation for active client packages.
+  - Current intended entrypoint: `.codex/scripts/typecheck.sh`
+- `python-tests`
+  - Purpose: run Python tests for active Python packages.
+  - Current intended entrypoint: `.codex/scripts/python-tests.sh`
+
+The top-level package-manager flows and the `.codex` action scripts must agree on the commands these entrypoints execute.
+
+## Bootstrap Contract
+
+`bootstrap` must make a fresh clone ready for active development and validation by:
+
+- installing Bun workspace dependencies for active TypeScript packages
+- syncing the `uv` workspace for active Python packages and dev dependencies
+- failing clearly when required tools such as `bun` or `uv` are unavailable
+
+`bootstrap` is successful when a fresh worktree can proceed directly to the relevant validation commands without manual package-manager recovery steps.
+
+## Validate Contract
+
+`validate` is the default aggregate validation command. It must fail fast on any failed sub-check and should cover the active repository surfaces with enough confidence for normal development work.
+
+`validate` must include:
+
+1. TypeScript type validation for active client packages.
+2. Python lint validation for active Python packages.
+3. Python type validation for active Python packages.
+4. Python tests for active Python packages.
+5. Lightweight smoke validation for critical Python entrypoints.
+
+`validate` may grow over time to include more checks, but it should remain a practical default command for local development rather than becoming a slow, release-only workflow.
+
+## Required Validation Layers
+
+Type validation is currently required for:
+
+- TypeScript
+- Python
+
+Additional languages should join the default type-validation surface when their server SDKs or other active package surfaces are implemented.
+
+### TypeScript
+
+The default TypeScript validation layer is `tsc`-based typechecking for:
+
+- `packages/clients/core`
+- `packages/clients/adapters/react-query`
+
+The current repository does not define a TypeScript linter. Until that changes, TypeScript correctness is enforced through typechecking and targeted tests.
+
+### Python
+
+The default Python validation layers are:
+
+- `ruff check` for active Python packages
+- `ty` for active Python packages
+- `pytest` for active Python packages
+
+Ruff is the standard Python lint layer for this repository. `ty` is the intended Python typechecking layer so the Python toolchain stays aligned with the Astral ecosystem where practical.
+
+The default Python lint and type layers should cover:
+
+- `apps/server`
+- `packages/server-sdks/python`
+
+Python tests should run the smallest relevant package scope first, then broaden when a change crosses package boundaries.
+
+### Smoke Checks
+
+The aggregate validation command should include lightweight import or construction smoke checks for critical entrypoints, such as:
+
+- the FastAPI application factory in `apps/server`
+- the Python server SDK configuration surface
+
+Smoke checks are not substitutes for behavior tests. They exist to catch obvious wiring failures early.
+
+## Protocol And Cross-Package Validation
+
+When a change touches RTRQ's documented protocol, validation must cover every active surface affected by that contract.
+
+At minimum, protocol changes should validate:
+
+- FastAPI request and response models
+- Python SDK request payloads and expectations
+- TypeScript client-side protocol handling for active client packages
+- any shared fixtures or schema examples introduced for protocol enforcement
+
+Once shared protocol fixtures exist, they should become the primary contract examples consumed by both Python and TypeScript validation.
+
+## Validation Selection Rules
+
+Developers and agents should prefer the smallest relevant validation that matches the change surface:
+
+- Python-only change in one package:
+  - run Ruff, Python type validation, and tests for that package first
+- TypeScript-only change:
+  - run active TypeScript type validation first
+- Cross-package or protocol change:
+  - run both Python and TypeScript validation for the affected active surfaces
+- Broad repository changes or handoff validation:
+  - run the aggregate `validate` command
+
+If a check is skipped, the reason should be explicit.
+
+## Current Gaps
+
+This contract is normative even when the current harness does not fully satisfy it.
+
+Known near-term work includes:
+
+- making the repo-owned aggregate validation command reliably green in fresh worktrees
+- wiring Ruff and `ty` consistently across both active Python packages
+- adding shared protocol fixtures and TypeScript protocol conformance tests
+- adding an end-to-end invalidation proof path
+- aligning future CI to this contract once the local harness is trustworthy
+
+## CI Alignment
+
+Future CI should mirror the repo-owned local validation entrypoints rather than inventing separate quality gates.
+
+CI should be added only after the local harness is reproducible and trustworthy. CI should not become the first place broken validation is discovered.

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -19,6 +19,7 @@ dev = [
   "build>=1.2.2",
   "httpx>=0.27.0",
   "pytest>=8.3.0",
+  "pytest-asyncio>=0.24.0",
   "ruff>=0.15.9",
   "ty>=0.0.29",
 ]

--- a/apps/server/src/rtrq_server/app.py
+++ b/apps/server/src/rtrq_server/app.py
@@ -15,6 +15,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     @app.post(
         f"{app_settings.api_prefix}/invalidate",
         response_model=InvalidationResponse,
+        status_code=200,
     )
     async def invalidate(_: InvalidationRequest) -> InvalidationResponse:
         return InvalidationResponse()
@@ -22,13 +23,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     @app.websocket("/ws")
     async def websocket_endpoint(websocket: WebSocket) -> None:
         await websocket.accept()
-        await websocket.send_json(
-            {
-                "type": "server_status",
-                "detail": "WebSocket skeleton is online. Auth and fan-out are pending.",
-            }
-        )
+        # Placeholder until handshake auth and typed message handling are implemented.
         await websocket.close(code=1013)
 
     return app
-

--- a/apps/server/src/rtrq_server/config.py
+++ b/apps/server/src/rtrq_server/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
 
 class Settings(BaseModel):
@@ -12,8 +12,7 @@ class Settings(BaseModel):
         default=None,
         description="Reserved for the future Redis pub/sub integration.",
     )
-    server_secret: str | None = Field(
+    server_secret: SecretStr | None = Field(
         default=None,
         description="Shared secret expected from trusted application servers.",
     )
-

--- a/apps/server/src/rtrq_server/models.py
+++ b/apps/server/src/rtrq_server/models.py
@@ -2,11 +2,10 @@ from pydantic import BaseModel, Field
 
 
 class InvalidationRequest(BaseModel):
-    keys: list[str] = Field(default_factory=list)
+    topics: list[str] = Field(default_factory=list)
     source: str | None = None
 
 
 class InvalidationResponse(BaseModel):
     accepted: bool = True
     detail: str = "Invalidation transport is not wired yet."
-

--- a/apps/server/tests/test_config.py
+++ b/apps/server/tests/test_config.py
@@ -1,9 +1,11 @@
+from pydantic import SecretStr
+
 from rtrq_server import config as server_config
 
 
 def test_server_secret_is_redacted_in_repr_and_json_dump() -> None:
     secret = "test-shared-secret"
-    settings = server_config.Settings(server_secret=secret)
+    settings = server_config.Settings(server_secret=SecretStr(secret))
 
     assert secret not in repr(settings)
     assert settings.model_dump(mode="json")["server_secret"] == "**********"

--- a/apps/server/tests/test_config.py
+++ b/apps/server/tests/test_config.py
@@ -1,9 +1,9 @@
-from rtrq_server.config import Settings
+from rtrq_server import config as server_config
 
 
 def test_server_secret_is_redacted_in_repr_and_json_dump() -> None:
     secret = "test-shared-secret"
-    settings = Settings(server_secret=secret)
+    settings = server_config.Settings(server_secret=secret)
 
     assert secret not in repr(settings)
     assert settings.model_dump(mode="json")["server_secret"] == "**********"

--- a/apps/server/tests/test_config.py
+++ b/apps/server/tests/test_config.py
@@ -1,0 +1,9 @@
+from rtrq_server.config import Settings
+
+
+def test_server_secret_is_redacted_in_repr_and_json_dump() -> None:
+    secret = "test-shared-secret"
+    settings = Settings(server_secret=secret)
+
+    assert secret not in repr(settings)
+    assert settings.model_dump(mode="json")["server_secret"] == "**********"

--- a/apps/server/tests/test_invalidation_api.py
+++ b/apps/server/tests/test_invalidation_api.py
@@ -1,0 +1,30 @@
+from fastapi.testclient import TestClient
+
+from rtrq_server.app import create_app
+
+
+def test_invalidate_accepts_keys_and_source() -> None:
+    client = TestClient(create_app())
+
+    response = client.post(
+        "/v1/invalidate",
+        json={"keys": ["todos", "users"], "source": "api"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "accepted": True,
+        "detail": "Invalidation transport is not wired yet.",
+    }
+
+
+def test_invalidate_defaults_source_to_none() -> None:
+    client = TestClient(create_app())
+
+    response = client.post("/v1/invalidate", json={"keys": ["todos"]})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "accepted": True,
+        "detail": "Invalidation transport is not wired yet.",
+    }

--- a/apps/server/tests/test_invalidation_api.py
+++ b/apps/server/tests/test_invalidation_api.py
@@ -1,15 +1,19 @@
-from fastapi.testclient import TestClient
+import pytest
+from httpx import ASGITransport, AsyncClient
 
 from rtrq_server.app import create_app
 
 
-def test_invalidate_accepts_topics_and_source() -> None:
-    client = TestClient(create_app())
+@pytest.mark.asyncio
+async def test_invalidate_accepts_topics_and_source() -> None:
+    app = create_app()
+    transport = ASGITransport(app=app)
 
-    response = client.post(
-        "/v1/invalidate",
-        json={"topics": ["todos", "users"], "source": "api"},
-    )
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/v1/invalidate",
+            json={"topics": ["todos", "users"], "source": "api"},
+        )
 
     assert response.status_code == 200
     assert response.json() == {
@@ -18,10 +22,13 @@ def test_invalidate_accepts_topics_and_source() -> None:
     }
 
 
-def test_invalidate_defaults_source_to_none() -> None:
-    client = TestClient(create_app())
+@pytest.mark.asyncio
+async def test_invalidate_defaults_source_to_none() -> None:
+    app = create_app()
+    transport = ASGITransport(app=app)
 
-    response = client.post("/v1/invalidate", json={"topics": ["todos"]})
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post("/v1/invalidate", json={"topics": ["todos"]})
 
     assert response.status_code == 200
     assert response.json() == {

--- a/apps/server/tests/test_invalidation_api.py
+++ b/apps/server/tests/test_invalidation_api.py
@@ -3,12 +3,12 @@ from fastapi.testclient import TestClient
 from rtrq_server.app import create_app
 
 
-def test_invalidate_accepts_keys_and_source() -> None:
+def test_invalidate_accepts_topics_and_source() -> None:
     client = TestClient(create_app())
 
     response = client.post(
         "/v1/invalidate",
-        json={"keys": ["todos", "users"], "source": "api"},
+        json={"topics": ["todos", "users"], "source": "api"},
     )
 
     assert response.status_code == 200
@@ -21,7 +21,7 @@ def test_invalidate_accepts_keys_and_source() -> None:
 def test_invalidate_defaults_source_to_none() -> None:
     client = TestClient(create_app())
 
-    response = client.post("/v1/invalidate", json={"keys": ["todos"]})
+    response = client.post("/v1/invalidate", json={"topics": ["todos"]})
 
     assert response.status_code == 200
     assert response.json() == {

--- a/package.json
+++ b/package.json
@@ -8,12 +8,17 @@
     "packages/clients/adapters/*"
   ],
   "scripts": {
+    "bootstrap": "./.codex/scripts/bootstrap.sh",
     "build": "bun run build:ts && bun run build:py",
     "build:ts": "bun run --filter @rtrq/client-core build && bun run --filter @rtrq/react-query build",
     "build:py": "./scripts/build-python.sh",
     "lock:py": "uv lock",
+    "lint:py": "./.codex/scripts/python-lint.sh",
     "setup:py": "./scripts/setup-python.sh",
     "typecheck": "bun run --filter @rtrq/client-core typecheck && bun run --filter @rtrq/react-query typecheck",
+    "typecheck:py": "./.codex/scripts/python-typecheck.sh",
+    "python-tests": "./.codex/scripts/python-tests.sh",
+    "validate": "./.codex/scripts/validate.sh",
     "dev:core": "bun run --filter @rtrq/client-core dev",
     "dev:react-query": "bun run --filter @rtrq/react-query dev",
     "dev:server": "./scripts/run-server-dev.sh",

--- a/packages/server-sdks/python/pyproject.toml
+++ b/packages/server-sdks/python/pyproject.toml
@@ -16,7 +16,9 @@ dependencies = [
 [dependency-groups]
 dev = [
   "build>=1.2.2",
-  "pytest>=8.3.0"
+  "pytest>=8.3.0",
+  "ruff>=0.15.9",
+  "ty>=0.0.29",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/packages/server-sdks/python/src/rtrq_server_sdk/__init__.py
+++ b/packages/server-sdks/python/src/rtrq_server_sdk/__init__.py
@@ -1,6 +1,11 @@
 """RTRQ Python server SDK."""
 
 from .client import RTRQServerSDK, RTRQServerSDKConfig
+from .security import RTRQ_SHARED_SECRET_HEADER, build_shared_secret_headers
 
-__all__ = ["RTRQServerSDK", "RTRQServerSDKConfig"]
-
+__all__ = [
+    "RTRQServerSDK",
+    "RTRQServerSDKConfig",
+    "RTRQ_SHARED_SECRET_HEADER",
+    "build_shared_secret_headers",
+]

--- a/packages/server-sdks/python/src/rtrq_server_sdk/__init__.py
+++ b/packages/server-sdks/python/src/rtrq_server_sdk/__init__.py
@@ -4,8 +4,8 @@ from .client import RTRQServerSDK, RTRQServerSDKConfig
 from .security import RTRQ_SHARED_SECRET_HEADER, build_shared_secret_headers
 
 __all__ = [
+    "build_shared_secret_headers",
     "RTRQServerSDK",
     "RTRQServerSDKConfig",
     "RTRQ_SHARED_SECRET_HEADER",
-    "build_shared_secret_headers",
 ]

--- a/packages/server-sdks/python/src/rtrq_server_sdk/client.py
+++ b/packages/server-sdks/python/src/rtrq_server_sdk/client.py
@@ -29,11 +29,11 @@ class RTRQServerSDK:
 
     async def invalidate(
         self,
-        keys: list[str],
+        topics: list[str],
         *,
         source: str | None = None,
     ) -> httpx.Response:
-        payload: dict[str, Any] = {"keys": keys}
+        payload: dict[str, Any] = {"topics": topics}
         if source is not None:
             payload["source"] = source
 

--- a/packages/server-sdks/python/src/rtrq_server_sdk/client.py
+++ b/packages/server-sdks/python/src/rtrq_server_sdk/client.py
@@ -1,14 +1,16 @@
 from typing import Any
 
 import httpx
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
+
+from .security import build_shared_secret_headers
 
 
 class RTRQServerSDKConfig(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     base_url: str
-    shared_secret: str
+    shared_secret: SecretStr
     timeout: float = Field(default=5.0, gt=0)
     api_prefix: str = "/v1"
 
@@ -38,7 +40,7 @@ class RTRQServerSDK:
         return await self._client.post(
             f"{self.config.api_prefix}/invalidate",
             json=payload,
-            headers={"x-rtrq-secret": self.config.shared_secret},
+            headers=build_shared_secret_headers(self.config.shared_secret),
         )
 
     async def aclose(self) -> None:

--- a/packages/server-sdks/python/src/rtrq_server_sdk/security.py
+++ b/packages/server-sdks/python/src/rtrq_server_sdk/security.py
@@ -1,0 +1,9 @@
+from pydantic import SecretStr
+
+RTRQ_SHARED_SECRET_HEADER = "x-rtrq-secret"
+
+
+def build_shared_secret_headers(shared_secret: SecretStr) -> dict[str, str]:
+    return {
+        RTRQ_SHARED_SECRET_HEADER: shared_secret.get_secret_value(),
+    }

--- a/packages/server-sdks/python/tests/test_client.py
+++ b/packages/server-sdks/python/tests/test_client.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 
 import httpx
+from pydantic import SecretStr
 
 from rtrq_server_sdk import RTRQServerSDK, RTRQServerSDKConfig
 from rtrq_server_sdk.security import RTRQ_SHARED_SECRET_HEADER
@@ -35,7 +36,7 @@ async def _send_invalidation(
     shared_secret = "test-shared-secret"
     config = RTRQServerSDKConfig(
         base_url="http://example.test",
-        shared_secret=shared_secret,
+        shared_secret=SecretStr(shared_secret),
     )
 
     async def handler(request: httpx.Request) -> httpx.Response:

--- a/packages/server-sdks/python/tests/test_client.py
+++ b/packages/server-sdks/python/tests/test_client.py
@@ -9,26 +9,26 @@ from rtrq_server_sdk.security import RTRQ_SHARED_SECRET_HEADER
 
 def test_invalidate_sends_expected_request() -> None:
     captured, response = asyncio.run(
-        _send_invalidation(keys=["todos", "users"], source="api"),
+        _send_invalidation(topics=["todos", "users"], source="api"),
     )
 
-    assert response.status_code == 202
+    assert response.status_code == 200
     assert captured["url"] == "http://example.test/v1/invalidate"
     assert captured["has_secret_header"] is True
     assert captured["secret_header_matches_config"] is True
-    assert captured["json"] == {"keys": ["todos", "users"], "source": "api"}
+    assert captured["json"] == {"topics": ["todos", "users"], "source": "api"}
 
 
 def test_invalidate_omits_source_when_not_provided() -> None:
-    captured, response = asyncio.run(_send_invalidation(keys=["todos"]))
+    captured, response = asyncio.run(_send_invalidation(topics=["todos"]))
 
-    assert response.status_code == 202
-    assert captured["json"] == {"keys": ["todos"]}
+    assert response.status_code == 200
+    assert captured["json"] == {"topics": ["todos"]}
 
 
 async def _send_invalidation(
     *,
-    keys: list[str],
+    topics: list[str],
     source: str | None = None,
 ) -> tuple[dict[str, object], httpx.Response]:
     captured: dict[str, object] = {}
@@ -46,14 +46,14 @@ async def _send_invalidation(
             == config.shared_secret.get_secret_value()
         )
         captured["json"] = json.loads(request.read().decode())
-        return httpx.Response(202, json={"ok": True})
+        return httpx.Response(200, json={"ok": True})
 
     transport = httpx.MockTransport(handler)
     client = httpx.AsyncClient(transport=transport, base_url="http://example.test")
     sdk = RTRQServerSDK(config, client=client)
 
     try:
-        response = await sdk.invalidate(keys, source=source)
+        response = await sdk.invalidate(topics, source=source)
     finally:
         await sdk.aclose()
 

--- a/packages/server-sdks/python/tests/test_client.py
+++ b/packages/server-sdks/python/tests/test_client.py
@@ -1,0 +1,60 @@
+import asyncio
+import json
+
+import httpx
+
+from rtrq_server_sdk import RTRQServerSDK, RTRQServerSDKConfig
+from rtrq_server_sdk.security import RTRQ_SHARED_SECRET_HEADER
+
+
+def test_invalidate_sends_expected_request() -> None:
+    captured, response = asyncio.run(
+        _send_invalidation(keys=["todos", "users"], source="api"),
+    )
+
+    assert response.status_code == 202
+    assert captured["url"] == "http://example.test/v1/invalidate"
+    assert captured["has_secret_header"] is True
+    assert captured["secret_header_matches_config"] is True
+    assert captured["json"] == {"keys": ["todos", "users"], "source": "api"}
+
+
+def test_invalidate_omits_source_when_not_provided() -> None:
+    captured, response = asyncio.run(_send_invalidation(keys=["todos"]))
+
+    assert response.status_code == 202
+    assert captured["json"] == {"keys": ["todos"]}
+
+
+async def _send_invalidation(
+    *,
+    keys: list[str],
+    source: str | None = None,
+) -> tuple[dict[str, object], httpx.Response]:
+    captured: dict[str, object] = {}
+    shared_secret = "test-shared-secret"
+    config = RTRQServerSDKConfig(
+        base_url="http://example.test",
+        shared_secret=shared_secret,
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["has_secret_header"] = RTRQ_SHARED_SECRET_HEADER in request.headers
+        captured["secret_header_matches_config"] = (
+            request.headers.get(RTRQ_SHARED_SECRET_HEADER)
+            == config.shared_secret.get_secret_value()
+        )
+        captured["json"] = json.loads(request.read().decode())
+        return httpx.Response(202, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport, base_url="http://example.test")
+    sdk = RTRQServerSDK(config, client=client)
+
+    try:
+        response = await sdk.invalidate(keys, source=source)
+    finally:
+        await sdk.aclose()
+
+    return captured, response

--- a/packages/server-sdks/python/tests/test_security.py
+++ b/packages/server-sdks/python/tests/test_security.py
@@ -1,3 +1,5 @@
+from pydantic import SecretStr
+
 from rtrq_server_sdk import RTRQServerSDKConfig
 from rtrq_server_sdk.security import (
     RTRQ_SHARED_SECRET_HEADER,
@@ -9,7 +11,7 @@ def test_shared_secret_is_redacted_in_repr_and_json_dump() -> None:
     secret = "test-shared-secret"
     config = RTRQServerSDKConfig(
         base_url="http://example.test",
-        shared_secret=secret,
+        shared_secret=SecretStr(secret),
     )
 
     assert secret not in repr(config)
@@ -19,7 +21,7 @@ def test_shared_secret_is_redacted_in_repr_and_json_dump() -> None:
 def test_build_shared_secret_headers_returns_auth_header() -> None:
     config = RTRQServerSDKConfig(
         base_url="http://example.test",
-        shared_secret="test-shared-secret",
+        shared_secret=SecretStr("test-shared-secret"),
     )
 
     assert build_shared_secret_headers(config.shared_secret) == {

--- a/packages/server-sdks/python/tests/test_security.py
+++ b/packages/server-sdks/python/tests/test_security.py
@@ -1,0 +1,27 @@
+from rtrq_server_sdk import RTRQServerSDKConfig
+from rtrq_server_sdk.security import (
+    RTRQ_SHARED_SECRET_HEADER,
+    build_shared_secret_headers,
+)
+
+
+def test_shared_secret_is_redacted_in_repr_and_json_dump() -> None:
+    secret = "test-shared-secret"
+    config = RTRQServerSDKConfig(
+        base_url="http://example.test",
+        shared_secret=secret,
+    )
+
+    assert secret not in repr(config)
+    assert config.model_dump(mode="json")["shared_secret"] == "**********"
+
+
+def test_build_shared_secret_headers_returns_auth_header() -> None:
+    config = RTRQServerSDKConfig(
+        base_url="http://example.test",
+        shared_secret="test-shared-secret",
+    )
+
+    assert build_shared_secret_headers(config.shared_secret) == {
+        RTRQ_SHARED_SECRET_HEADER: "test-shared-secret",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -557,6 +557,8 @@ dependencies = [
 dev = [
     { name = "build" },
     { name = "pytest" },
+    { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -569,6 +571,8 @@ requires-dist = [
 dev = [
     { name = "build", specifier = ">=1.2.2" },
     { name = "pytest", specifier = ">=8.3.0" },
+    { name = "ruff", specifier = ">=0.15.9" },
+    { name = "ty", specifier = ">=0.0.29" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -41,6 +41,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "build"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -412,6 +421,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -499,6 +522,7 @@ dev = [
     { name = "build" },
     { name = "httpx" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -515,6 +539,7 @@ dev = [
     { name = "build", specifier = ">=1.2.2" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pytest", specifier = ">=8.3.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "ruff", specifier = ">=0.15.9" },
     { name = "ty", specifier = ">=0.0.29" },
 ]


### PR DESCRIPTION
## Summary
- Clarified the RTRQ contract around canonical topic keys, WebSocket message taxonomy, and fail-safe adapter behavior.
- Updated the server invalidation API to use `topics` and return `200 OK` for accepted requests.
- Redacted shared secrets with `SecretStr` in the server and Python SDK, and added a helper for auth headers.
- Added repo guidance in `AGENTS.md` and durable invariants in `INVARIANTS.md`.
- Added tests covering invalidation request handling, secret redaction, and SDK request/auth behavior.

## Testing
- `apps/server/tests/test_config.py` added for secret redaction behavior.
- `apps/server/tests/test_invalidation_api.py` added for `/v1/invalidate` request shape and response status.
- `packages/server-sdks/python/tests/test_security.py` added for secret redaction and header construction.
- `packages/server-sdks/python/tests/test_client.py` added for SDK request payload and auth header checks.
- Not run: full test suite and cross-package type checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded protocol docs with formal invariants, topic-key semantics, placement rubric, escalation guidance, and a new validation contract; README path fixed and local tooling docs updated.

* **API Changes**
  * Invalidation payloads and docs renamed from “keys” to “topics”; HTTP /invalidate now explicitly acknowledges with 200; WebSocket/subscription semantics clarified.

* **Bug Fixes & Improvements**
  * Secrets typed/redacted and shared-secret header helper added; SDK exports updated.

* **Tests**
  * Added tests for invalidation API, secret redaction, and SDK request behavior.

* **Chores**
  * Added Python lint/typecheck/test scripts, bootstrap safeguard, and async-test tooling to dev dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->