### PR TITLE
Add shared protocol fixture validation

### DIFF
--- a/.codex/scripts/bootstrap.sh
+++ b/.codex/scripts/bootstrap.sh
@@ -15,11 +15,57 @@ fi
 
 cd "${ROOT_DIR}"
 
-if bun --eval 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); const sections = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"]; const bad = sections.find((section) => pkg[section]?.tsc); if (bad) { console.error("The npm package \"tsc\" shadows the real TypeScript compiler. Remove it and rely on the \"typescript\" package instead."); process.exit(1); }'; then
-  :
-else
-  exit 1
-fi
+bun --eval '
+const fs = require("fs");
+const path = require("path");
+
+const rootDir = process.cwd();
+const message = "The npm package \"tsc\" shadows the real TypeScript compiler. Remove it and rely on the \"typescript\" package instead.";
+const sections = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
+
+function readPackageJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function hasShadowingTsc(pkg) {
+  return sections.some((section) => pkg[section]?.tsc);
+}
+
+const rootPackagePath = path.join(rootDir, "package.json");
+const rootPackage = readPackageJson(rootPackagePath);
+const packageJsonPaths = [rootPackagePath];
+
+for (const workspaceEntry of rootPackage.workspaces ?? []) {
+  if (workspaceEntry.endsWith("/*")) {
+    const workspaceRoot = path.join(rootDir, workspaceEntry.slice(0, -2));
+
+    for (const dirent of fs.readdirSync(workspaceRoot, { withFileTypes: true })) {
+      if (!dirent.isDirectory()) {
+        continue;
+      }
+
+      const packagePath = path.join(workspaceRoot, dirent.name, "package.json");
+      if (fs.existsSync(packagePath)) {
+        packageJsonPaths.push(packagePath);
+      }
+    }
+    continue;
+  }
+
+  const packagePath = path.join(rootDir, workspaceEntry, "package.json");
+  if (fs.existsSync(packagePath)) {
+    packageJsonPaths.push(packagePath);
+  }
+}
+
+for (const packagePath of packageJsonPaths) {
+  const pkg = readPackageJson(packagePath);
+  if (hasShadowingTsc(pkg)) {
+    console.error(message);
+    process.exit(1);
+  }
+}
+'
 
 bun install --frozen-lockfile
 

--- a/.codex/scripts/bootstrap.sh
+++ b/.codex/scripts/bootstrap.sh
@@ -15,5 +15,17 @@ fi
 
 cd "${ROOT_DIR}"
 
+if bun --eval 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); const sections = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"]; const bad = sections.find((section) => pkg[section]?.tsc); if (bad) { console.error("The npm package \"tsc\" shadows the real TypeScript compiler. Remove it and rely on the \"typescript\" package instead."); process.exit(1); }'; then
+  :
+else
+  exit 1
+fi
+
 bun install --frozen-lockfile
+
+if [[ -e "${ROOT_DIR}/node_modules/tsc/package.json" ]]; then
+  echo "Found node_modules/tsc after install. This package shadows the real TypeScript compiler; remove the stale install state and rerun bootstrap." >&2
+  exit 1
+fi
+
 uv sync --project "${ROOT_DIR}" --all-packages --all-groups

--- a/.codex/scripts/validate.sh
+++ b/.codex/scripts/validate.sh
@@ -9,6 +9,8 @@ if ! command -v uv >/dev/null 2>&1; then
 fi
 
 "${ROOT_DIR}/.codex/scripts/typecheck.sh"
+cd "${ROOT_DIR}"
+bun run validate:protocol-fixtures:ts
 "${ROOT_DIR}/.codex/scripts/python-lint.sh"
 "${ROOT_DIR}/.codex/scripts/python-typecheck.sh"
 "${ROOT_DIR}/.codex/scripts/python-tests.sh"

--- a/.codex/scripts/validate.sh
+++ b/.codex/scripts/validate.sh
@@ -8,6 +8,11 @@ if ! command -v uv >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v bun >/dev/null 2>&1; then
+  echo "bun is required for repository validation." >&2
+  exit 1
+fi
+
 "${ROOT_DIR}/.codex/scripts/typecheck.sh"
 cd "${ROOT_DIR}"
 bun run validate:protocol-fixtures:ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,16 @@
-## Repository Contract
+## Knowledge Index
 
-- Product and architecture source of truth: `RTRQ.md`.
-- Workspace layout, package locations, and top-level scripts: `README.md`.
+- Architecture and product source of truth: `RTRQ.md`.
+- Protocol source of truth: `RTRQ.md`.
 - Invariant source of truth: `INVARIANTS.md`.
-- Validation source of truth: `VALIDATION.md`.
+- Validation and execution workflow source of truth: `VALIDATION.md`.
+- Workspace layout, package locations, and top-level scripts: `README.md`.
 - Package manifests and existing source files define the executable contract when docs and code diverge.
 - Nested `AGENTS.md` files override this file for their subtree. Today that mainly applies to `apps/server/`.
 
-## What RTRQ Is
+## Execution Notes
 
-- RTRQ is a self-hosted real-time cache invalidation layer. It accelerates invalidation for React Query-style clients; it does not replace the application's existing fetch and refetch logic.
-- The core architecture is: app server calls RTRQ over HTTP, RTRQ fans invalidations out over WebSockets, Redis is the future inter-node backbone, and client adapters trigger library-native invalidation behavior.
+- RTRQ is a self-hosted real-time cache invalidation layer that accelerates invalidation; it does not replace the application's existing fetch and refetch logic.
 - Preserve the "degraded speed, not broken functionality" design goal. New work should fail-safe when RTRQ is unavailable.
 
 ## Active Surfaces

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -122,6 +122,8 @@ At minimum, protocol changes should validate:
 
 Once shared protocol fixtures exist, they should become the primary contract examples consumed by both Python and TypeScript validation.
 
+The shared protocol fixtures live in `fixtures/protocol/` and are repository-owned contract examples for active-surface validation.
+
 ## Validation Selection Rules
 
 Developers and agents should prefer the smallest relevant validation that matches the change surface:
@@ -145,7 +147,7 @@ Known near-term work includes:
 
 - making the repo-owned aggregate validation command reliably green in fresh worktrees
 - wiring Ruff and `ty` consistently across both active Python packages
-- adding shared protocol fixtures and TypeScript protocol conformance tests
+- expanding TypeScript protocol conformance tests around the shared protocol fixtures
 - adding an end-to-end invalidation proof path
 - aligning future CI to this contract once the local harness is trustworthy
 

--- a/apps/server/tests/test_protocol_fixtures.py
+++ b/apps/server/tests/test_protocol_fixtures.py
@@ -1,0 +1,177 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from rtrq_server.app import create_app
+
+
+def test_valid_topic_fixtures_are_canonical() -> None:
+    fixtures = _load_fixture("topics.json")
+
+    for example in fixtures["valid"]:
+        assert _canonical_topic(example["logicalKey"]) == example["topic"]
+
+
+def test_invalid_topic_fixtures_are_rejected() -> None:
+    fixtures = _load_fixture("topics.json")
+
+    for example in fixtures["invalid"]:
+        json_text = example["jsonText"]
+        assert _is_valid_topic_string(json_text) is False
+
+
+def test_valid_websocket_message_fixtures_match_mvp_taxonomy() -> None:
+    fixtures = _load_fixture("websocket-messages.json")
+
+    for example in fixtures["valid"]:
+        assert _is_valid_websocket_message(example["message"]) is True
+
+
+def test_invalid_websocket_message_fixtures_are_rejected() -> None:
+    fixtures = _load_fixture("websocket-messages.json")
+
+    for example in fixtures["invalid"]:
+        assert _is_valid_websocket_message(example["message"]) is False
+
+
+@pytest.mark.asyncio
+async def test_valid_http_invalidation_fixtures_match_server_contract() -> None:
+    fixtures = _load_fixture("http-invalidation.json")
+    responses_by_name = {
+        response["name"]: response for response in fixtures["valid"]["responses"]
+    }
+    app = create_app()
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        for example in fixtures["valid"]["requests"]:
+            response = await client.post(
+                "/v1/invalidate",
+                headers=example["headers"],
+                json=example["body"],
+            )
+
+            expected = responses_by_name[example["expectedResponse"]]
+            assert response.status_code == expected["status"]
+            assert response.json() == expected["body"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_http_invalidation_fixtures_are_rejected() -> None:
+    fixtures = _load_fixture("http-invalidation.json")
+    app = create_app()
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        for example in fixtures["invalid"]["requests"]:
+            response = await client.post(
+                "/v1/invalidate",
+                headers=example["headers"],
+                json=example["body"],
+            )
+
+            assert response.status_code == example["expectedStatus"]
+
+
+def _load_fixture(name: str) -> dict[str, Any]:
+    return json.loads((_fixture_dir() / name).read_text())
+
+
+def _fixture_dir() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "fixtures" / "protocol"
+        if candidate.is_dir():
+            return candidate
+
+    raise RuntimeError("Could not locate fixtures/protocol directory.")
+
+
+def _canonical_topic(value: Any) -> str:
+    if not isinstance(value, list):
+        raise ValueError("Topic logical keys must be JSON arrays.")
+
+    return json.dumps(_canonicalize_json(value), separators=(",", ":"))
+
+
+def _canonicalize_json(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_canonicalize_json(item) for item in value]
+
+    if isinstance(value, dict):
+        return {
+            key: _canonicalize_json(value[key])
+            for key in sorted(value.keys())
+        }
+
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+
+    raise ValueError("Unsupported JSON value.")
+
+
+def _is_valid_topic_string(topic: str) -> bool:
+    try:
+        parsed = json.loads(topic)
+    except json.JSONDecodeError:
+        return False
+
+    if not isinstance(parsed, list):
+        return False
+
+    return _canonical_topic(parsed) == topic
+
+
+def _is_valid_websocket_message(message: Any) -> bool:
+    if not isinstance(message, dict):
+        return False
+
+    message_type = message.get("type")
+    if not isinstance(message_type, str):
+        return False
+
+    if message_type in {"subscribe", "unsubscribe"}:
+        return _is_non_empty_string(message.get("op_id")) and _is_non_empty_topic_list(
+            message.get("topics"),
+        )
+
+    if message_type == "ready":
+        return _is_non_empty_string(message.get("connection_id"))
+
+    if message_type == "subscription_ack":
+        return (
+            _is_non_empty_string(message.get("op_id"))
+            and message.get("action") in {"subscribe", "unsubscribe"}
+            and isinstance(message.get("topic_count"), int)
+            and message["topic_count"] >= 0
+            and message.get("result") == "applied"
+        )
+
+    if message_type == "invalidation":
+        return _is_non_empty_string(message.get("delivery_id")) and _is_non_empty_topic_list(
+            message.get("topics"),
+        )
+
+    if message_type == "error":
+        op_id = message.get("op_id")
+        return (
+            (op_id is None or _is_non_empty_string(op_id))
+            and _is_non_empty_string(message.get("code"))
+            and _is_non_empty_string(message.get("detail"))
+        )
+
+    return False
+
+
+def _is_non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and value != ""
+
+
+def _is_non_empty_topic_list(value: Any) -> bool:
+    return (
+        isinstance(value, list)
+        and value != []
+        and all(_is_valid_topic_string(topic) for topic in value)
+    )

--- a/apps/server/tests/test_protocol_fixtures.py
+++ b/apps/server/tests/test_protocol_fixtures.py
@@ -74,6 +74,11 @@ async def test_invalid_http_invalidation_fixtures_are_rejected() -> None:
             )
 
             assert response.status_code == example["expectedStatus"]
+            if example["expectedStatus"] == 422:
+                payload = response.json()
+                assert "detail" in payload
+                assert payload["detail"]
+                assert example["reason"]
 
 
 def _load_fixture(name: str) -> dict[str, Any]:

--- a/fixtures/protocol/README.md
+++ b/fixtures/protocol/README.md
@@ -1,0 +1,28 @@
+# Shared Protocol Fixtures
+
+This directory contains repo-owned contract fixtures for RTRQ's active protocol surfaces.
+
+Ownership:
+
+- The repository owns these fixtures as durable technical contract examples.
+- Changes here should stay aligned with `RTRQ.md`, `INVARIANTS.md`, and `VALIDATION.md`.
+- If a protocol rule changes, update the docs and these fixtures in the same change.
+
+Intended consumers:
+
+- Python validation in `apps/server/tests`
+- Python validation in `packages/server-sdks/python/tests`
+- TypeScript validation via `scripts/validate-protocol-fixtures.ts`
+- Future protocol conformance and end-to-end harnesses
+
+Fixture files:
+
+- `topics.json`: valid and invalid canonical topic examples
+- `websocket-messages.json`: valid and invalid MVP WebSocket message examples
+- `http-invalidation.json`: HTTP invalidation request and response examples for the active server and Python SDK contract
+
+Format notes:
+
+- Valid examples use JSON-native values so multiple languages can load them directly.
+- Invalid wire examples use `jsonText` strings when the example cannot be represented as valid JSON data.
+- Example credentials are placeholders only. They are test fixtures, not real secrets.

--- a/fixtures/protocol/http-invalidation.json
+++ b/fixtures/protocol/http-invalidation.json
@@ -1,0 +1,66 @@
+{
+  "valid": {
+    "requests": [
+      {
+        "name": "accepted_with_source",
+        "headers": {
+          "x-rtrq-secret": "example-shared-secret"
+        },
+        "body": {
+          "topics": [
+            "[\"todos\"]",
+            "[\"todos\",{\"filter\":\"active\",\"userId\":\"123\"}]"
+          ],
+          "source": "api"
+        },
+        "expectedResponse": "accepted"
+      },
+      {
+        "name": "accepted_without_source",
+        "headers": {
+          "x-rtrq-secret": "example-shared-secret"
+        },
+        "body": {
+          "topics": ["[\"todos\"]"]
+        },
+        "expectedResponse": "accepted"
+      }
+    ],
+    "responses": [
+      {
+        "name": "accepted",
+        "status": 200,
+        "body": {
+          "accepted": true,
+          "detail": "Invalidation transport is not wired yet."
+        }
+      }
+    ]
+  },
+  "invalid": {
+    "requests": [
+      {
+        "name": "topics_not_array",
+        "headers": {
+          "x-rtrq-secret": "example-shared-secret"
+        },
+        "body": {
+          "topics": "[\"todos\"]"
+        },
+        "expectedStatus": 422,
+        "reason": "The active HTTP contract requires topics to be a JSON array of strings."
+      },
+      {
+        "name": "topics_contains_non_string",
+        "headers": {
+          "x-rtrq-secret": "example-shared-secret"
+        },
+        "body": {
+          "topics": ["[\"todos\"]", 123]
+        },
+        "expectedStatus": 422,
+        "reason": "Each topic must be a string."
+      }
+    ]
+  }
+}

--- a/fixtures/protocol/topics.json
+++ b/fixtures/protocol/topics.json
@@ -1,0 +1,50 @@
+{
+  "valid": [
+    {
+      "name": "simple_prefix",
+      "logicalKey": ["todos"],
+      "topic": "[\"todos\"]"
+    },
+    {
+      "name": "canonical_object_segment",
+      "logicalKey": ["todos", { "filter": "active", "userId": "123" }],
+      "topic": "[\"todos\",{\"filter\":\"active\",\"userId\":\"123\"}]"
+    },
+    {
+      "name": "nested_structures",
+      "logicalKey": [
+        "feed",
+        {
+          "filters": {
+            "archived": false,
+            "tags": ["a", "b"]
+          },
+          "page": 1
+        }
+      ],
+      "topic": "[\"feed\",{\"filters\":{\"archived\":false,\"tags\":[\"a\",\"b\"]},\"page\":1}]"
+    }
+  ],
+  "invalid": [
+    {
+      "name": "top_level_not_array",
+      "jsonText": "\"todos\"",
+      "reason": "The top-level protocol value must be a JSON array."
+    },
+    {
+      "name": "non_canonical_object_key_order",
+      "jsonText": "[\"todos\",{\"userId\":\"123\",\"filter\":\"active\"}]",
+      "reason": "Object keys must be sorted recursively for canonical topic identity."
+    },
+    {
+      "name": "invalid_json_token",
+      "jsonText": "[\"todos\", undefined]",
+      "reason": "Values outside the JSON data model are not transportable."
+    },
+    {
+      "name": "malformed_json",
+      "jsonText": "[\"todos\",]",
+      "reason": "Topic strings must be valid JSON."
+    }
+  ]
+}

--- a/fixtures/protocol/websocket-messages.json
+++ b/fixtures/protocol/websocket-messages.json
@@ -1,0 +1,112 @@
+{
+  "valid": [
+    {
+      "name": "subscribe_basic",
+      "direction": "client_to_server",
+      "message": {
+        "type": "subscribe",
+        "op_id": "op-sub-1",
+        "topics": ["[\"todos\"]"]
+      }
+    },
+    {
+      "name": "unsubscribe_multiple_topics",
+      "direction": "client_to_server",
+      "message": {
+        "type": "unsubscribe",
+        "op_id": "op-unsub-1",
+        "topics": [
+          "[\"todos\"]",
+          "[\"todos\",{\"filter\":\"active\",\"userId\":\"123\"}]"
+        ]
+      }
+    },
+    {
+      "name": "ready_basic",
+      "direction": "server_to_client",
+      "message": {
+        "type": "ready",
+        "connection_id": "conn-1"
+      }
+    },
+    {
+      "name": "subscription_ack_basic",
+      "direction": "server_to_client",
+      "message": {
+        "type": "subscription_ack",
+        "op_id": "op-sub-1",
+        "action": "subscribe",
+        "topic_count": 2,
+        "result": "applied"
+      }
+    },
+    {
+      "name": "invalidation_multiple_topics",
+      "direction": "server_to_client",
+      "message": {
+        "type": "invalidation",
+        "delivery_id": "delivery-1",
+        "topics": [
+          "[\"todos\"]",
+          "[\"todos\",{\"filter\":\"active\",\"userId\":\"123\"}]"
+        ]
+      }
+    },
+    {
+      "name": "error_with_op_id",
+      "direction": "server_to_client",
+      "message": {
+        "type": "error",
+        "op_id": "op-sub-2",
+        "code": "invalid_topics",
+        "detail": "Topics payload must be a non-empty string array."
+      }
+    }
+  ],
+  "invalid": [
+    {
+      "name": "subscribe_empty_topics",
+      "message": {
+        "type": "subscribe",
+        "op_id": "op-empty",
+        "topics": []
+      },
+      "reason": "Subscription mutations require a non-empty topics array."
+    },
+    {
+      "name": "invalidation_scalar_topics",
+      "message": {
+        "type": "invalidation",
+        "delivery_id": "delivery-2",
+        "topics": "[\"todos\"]"
+      },
+      "reason": "Invalidation messages must carry topics: string[]."
+    },
+    {
+      "name": "subscription_ack_missing_op_id",
+      "message": {
+        "type": "subscription_ack",
+        "action": "subscribe",
+        "topic_count": 1,
+        "result": "applied"
+      },
+      "reason": "subscription_ack requires op_id."
+    },
+    {
+      "name": "unknown_message_type",
+      "message": {
+        "type": "sync",
+        "topics": ["[\"todos\"]"]
+      },
+      "reason": "The MVP message taxonomy is closed to the documented message types."
+    },
+    {
+      "name": "error_missing_detail",
+      "message": {
+        "type": "error",
+        "code": "invalid_topics"
+      },
+      "reason": "error messages require both code and detail."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "setup:py": "./scripts/setup-python.sh",
     "typecheck": "bun run --filter @rtrq/client-core typecheck && bun run --filter @rtrq/react-query typecheck",
     "typecheck:py": "./.codex/scripts/python-typecheck.sh",
+    "validate:protocol-fixtures:ts": "bun run ./scripts/validate-protocol-fixtures.ts",
     "python-tests": "./.codex/scripts/python-tests.sh",
     "validate": "./.codex/scripts/validate.sh",
     "dev:core": "bun run --filter @rtrq/client-core dev",

--- a/packages/clients/adapters/react-query/package.json
+++ b/packages/clients/adapters/react-query/package.json
@@ -31,4 +31,3 @@
     "@tanstack/react-query": "^5.66.9"
   }
 }
-

--- a/packages/clients/core/package.json
+++ b/packages/clients/core/package.json
@@ -22,4 +22,3 @@
     "typecheck": "tsc -p tsconfig.json"
   }
 }
-

--- a/packages/server-sdks/python/tests/test_protocol_fixtures.py
+++ b/packages/server-sdks/python/tests/test_protocol_fixtures.py
@@ -1,0 +1,86 @@
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+from pydantic import SecretStr
+
+from rtrq_server_sdk import RTRQServerSDK, RTRQServerSDKConfig
+
+
+def test_sdk_matches_valid_http_request_fixtures() -> None:
+    fixtures = _load_fixture("http-invalidation.json")
+
+    for example in fixtures["valid"]["requests"]:
+        captured, response = asyncio.run(_send_fixture_request(example))
+
+        assert response.status_code == 200
+        assert captured["url"] == "http://example.test/v1/invalidate"
+        assert captured["json"] == example["body"]
+        assert captured["headers_match_fixture"] is True
+
+
+def test_sdk_uses_valid_topic_fixture_values() -> None:
+    fixtures = _load_fixture("topics.json")
+    valid_topics = [example["topic"] for example in fixtures["valid"]]
+
+    captured, response = asyncio.run(_send_topics(valid_topics[:2]))
+
+    assert response.status_code == 200
+    assert captured["json"] == {"topics": valid_topics[:2]}
+
+
+async def _send_fixture_request(
+    example: dict[str, Any],
+) -> tuple[dict[str, object], httpx.Response]:
+    return await _send_topics(
+        example["body"]["topics"],
+        source=example["body"].get("source"),
+        secret=example["headers"]["x-rtrq-secret"],
+    )
+
+
+async def _send_topics(
+    topics: list[str],
+    *,
+    source: str | None = None,
+    secret: str = "example-shared-secret",
+) -> tuple[dict[str, object], httpx.Response]:
+    captured: dict[str, object] = {}
+    config = RTRQServerSDKConfig(
+        base_url="http://example.test",
+        shared_secret=SecretStr(secret),
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["json"] = json.loads(request.read().decode())
+        captured["headers_match_fixture"] = (
+            request.headers.get("x-rtrq-secret") == config.shared_secret.get_secret_value()
+        )
+        return httpx.Response(200, json={"accepted": True})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport, base_url="http://example.test")
+    sdk = RTRQServerSDK(config, client=client)
+
+    try:
+        response = await sdk.invalidate(topics, source=source)
+    finally:
+        await sdk.aclose()
+
+    return captured, response
+
+
+def _load_fixture(name: str) -> dict[str, Any]:
+    return json.loads((_fixture_dir() / name).read_text())
+
+
+def _fixture_dir() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "fixtures" / "protocol"
+        if candidate.is_dir():
+            return candidate
+
+    raise RuntimeError("Could not locate fixtures/protocol directory.")

--- a/packages/server-sdks/python/tests/test_protocol_fixtures.py
+++ b/packages/server-sdks/python/tests/test_protocol_fixtures.py
@@ -45,7 +45,7 @@ async def _send_topics(
     topics: list[str],
     *,
     source: str | None = None,
-    secret: str = "example-shared-secret",
+    secret: str = "example-shared-secret",  # noqa: S107
 ) -> tuple[dict[str, object], httpx.Response]:
     captured: dict[str, object] = {}
     config = RTRQServerSDKConfig(

--- a/scripts/validate-protocol-fixtures.ts
+++ b/scripts/validate-protocol-fixtures.ts
@@ -1,0 +1,217 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+type TopicFixture = {
+  name: string;
+  logicalKey: JsonValue[];
+  topic: string;
+};
+
+type InvalidTopicFixture = {
+  name: string;
+  jsonText: string;
+  reason: string;
+};
+
+type WebSocketFixture = {
+  name: string;
+  direction: "client_to_server" | "server_to_client";
+  message: Record<string, unknown>;
+};
+
+type InvalidWebSocketFixture = {
+  name: string;
+  message: Record<string, unknown>;
+  reason: string;
+};
+
+type HttpRequestFixture = {
+  name: string;
+  headers: Record<string, string>;
+  body: {
+    topics: string[];
+    source?: string;
+  };
+  expectedResponse: string;
+};
+
+type HttpResponseFixture = {
+  name: string;
+  status: number;
+  body: Record<string, unknown>;
+};
+
+const fixtureDir = path.join(process.cwd(), "fixtures", "protocol");
+
+const topicsFixtures = readJson<{
+  valid: TopicFixture[];
+  invalid: InvalidTopicFixture[];
+}>("topics.json");
+const websocketFixtures = readJson<{
+  valid: WebSocketFixture[];
+  invalid: InvalidWebSocketFixture[];
+}>("websocket-messages.json");
+const httpFixtures = readJson<{
+  valid: {
+    requests: HttpRequestFixture[];
+    responses: HttpResponseFixture[];
+  };
+  invalid: {
+    requests: Array<{
+      name: string;
+      headers: Record<string, string>;
+      body: Record<string, unknown>;
+      expectedStatus: number;
+      reason: string;
+    }>;
+  };
+}>("http-invalidation.json");
+
+for (const example of topicsFixtures.valid) {
+  assert(
+    canonicalTopic(example.logicalKey) === example.topic,
+    `Valid topic fixture ${example.name} is not canonical.`,
+  );
+}
+
+for (const example of topicsFixtures.invalid) {
+  assert(
+    isValidTopicString(example.jsonText) === false,
+    `Invalid topic fixture ${example.name} was treated as valid.`,
+  );
+}
+
+for (const example of websocketFixtures.valid) {
+  assert(
+    isValidWebSocketMessage(example.message),
+    `Valid WebSocket fixture ${example.name} failed validation.`,
+  );
+}
+
+for (const example of websocketFixtures.invalid) {
+  assert(
+    isValidWebSocketMessage(example.message) === false,
+    `Invalid WebSocket fixture ${example.name} was treated as valid.`,
+  );
+}
+
+const httpResponses = new Map(
+  httpFixtures.valid.responses.map((response) => [response.name, response]),
+);
+
+for (const request of httpFixtures.valid.requests) {
+  assert(
+    request.headers["x-rtrq-secret"] !== undefined,
+    `HTTP fixture ${request.name} must include the shared secret header example.`,
+  );
+  assert(
+    isNonEmptyTopicList(request.body.topics),
+    `HTTP fixture ${request.name} must use a non-empty topics array.`,
+  );
+  assert(
+    httpResponses.has(request.expectedResponse),
+    `HTTP fixture ${request.name} references a missing response fixture.`,
+  );
+}
+
+for (const request of httpFixtures.invalid.requests) {
+  assert(
+    Number.isInteger(request.expectedStatus) && request.expectedStatus >= 400,
+    `Invalid HTTP fixture ${request.name} must define an error status.`,
+  );
+}
+
+function readJson<T>(name: string): T {
+  const content = readFileSync(path.join(fixtureDir, name), "utf8");
+  return JSON.parse(content) as T;
+}
+
+function canonicalTopic(value: JsonValue): string {
+  assert(Array.isArray(value), "Topic logical keys must be JSON arrays.");
+  return JSON.stringify(canonicalizeJson(value));
+}
+
+function canonicalizeJson(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) {
+    return value.map(canonicalizeJson);
+  }
+
+  if (value !== null && typeof value === "object") {
+    const entries = Object.entries(value).sort(([left], [right]) =>
+      left.localeCompare(right),
+    );
+    return Object.fromEntries(
+      entries.map(([key, entryValue]) => [key, canonicalizeJson(entryValue)]),
+    );
+  }
+
+  return value;
+}
+
+function isValidTopicString(topic: string): boolean {
+  try {
+    const parsed = JSON.parse(topic) as JsonValue;
+    return Array.isArray(parsed) && canonicalTopic(parsed) === topic;
+  } catch {
+    return false;
+  }
+}
+
+function isValidWebSocketMessage(message: Record<string, unknown>): boolean {
+  const messageType = message.type;
+  if (typeof messageType !== "string") {
+    return false;
+  }
+
+  switch (messageType) {
+    case "subscribe":
+    case "unsubscribe":
+      return (
+        isNonEmptyString(message.op_id) && isNonEmptyTopicList(message.topics)
+      );
+    case "ready":
+      return isNonEmptyString(message.connection_id);
+    case "subscription_ack":
+      return (
+        isNonEmptyString(message.op_id) &&
+        (message.action === "subscribe" || message.action === "unsubscribe") &&
+        Number.isInteger(message.topic_count) &&
+        (message.topic_count as number) >= 0 &&
+        message.result === "applied"
+      );
+    case "invalidation":
+      return (
+        isNonEmptyString(message.delivery_id) &&
+        isNonEmptyTopicList(message.topics)
+      );
+    case "error":
+      return (
+        (message.op_id === undefined || isNonEmptyString(message.op_id)) &&
+        isNonEmptyString(message.code) &&
+        isNonEmptyString(message.detail)
+      );
+    default:
+      return false;
+  }
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isNonEmptyTopicList(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((entry) => typeof entry === "string" && isValidTopicString(entry))
+  );
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/scripts/validate-protocol-fixtures.ts
+++ b/scripts/validate-protocol-fixtures.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 type JsonPrimitive = string | number | boolean | null;
@@ -44,7 +45,8 @@ type HttpResponseFixture = {
   body: Record<string, unknown>;
 };
 
-const fixtureDir = path.join(process.cwd(), "fixtures", "protocol");
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const fixtureDir = path.join(scriptDir, "..", "fixtures", "protocol");
 
 const topicsFixtures = readJson<{
   valid: TopicFixture[];
@@ -141,7 +143,7 @@ function canonicalizeJson(value: JsonValue): JsonValue {
 
   if (value !== null && typeof value === "object") {
     const entries = Object.entries(value).sort(([left], [right]) =>
-      left.localeCompare(right),
+      compareUnicodeCodePoints(left, right),
     );
     return Object.fromEntries(
       entries.map(([key, entryValue]) => [key, canonicalizeJson(entryValue)]),
@@ -158,6 +160,42 @@ function isValidTopicString(topic: string): boolean {
   } catch {
     return false;
   }
+}
+
+function compareUnicodeCodePoints(left: string, right: string): number {
+  const leftPoints = Array.from(left);
+  const rightPoints = Array.from(right);
+  const maxLength = Math.max(leftPoints.length, rightPoints.length);
+
+  for (let index = 0; index < maxLength; index += 1) {
+    const leftPoint = leftPoints[index];
+    const rightPoint = rightPoints[index];
+
+    if (leftPoint === undefined) {
+      return -1;
+    }
+
+    if (rightPoint === undefined) {
+      return 1;
+    }
+
+    const leftValue = leftPoint.codePointAt(0);
+    const rightValue = rightPoint.codePointAt(0);
+
+    if (leftValue === undefined || rightValue === undefined) {
+      continue;
+    }
+
+    if (leftValue < rightValue) {
+      return -1;
+    }
+
+    if (leftValue > rightValue) {
+      return 1;
+    }
+  }
+
+  return 0;
 }
 
 function isValidWebSocketMessage(message: Record<string, unknown>): boolean {


### PR DESCRIPTION
## Summary
- Add shared protocol fixtures under `fixtures/protocol/` for topics, WebSocket messages, and HTTP invalidation requests/responses.
- Add Python and TypeScript validation coverage to ensure the fixtures stay aligned with the active server and SDK contracts.
- Tighten bootstrap and repo guidance to catch `tsc` package shadowing and clarify the source-of-truth docs.
- Wire shared protocol fixture validation into the top-level validation script.

## Testing
- Not run in this environment.
- Added Python fixture tests in `apps/server/tests/test_protocol_fixtures.py` and `packages/server-sdks/python/tests/test_protocol_fixtures.py`.
- Added TypeScript fixture validation in `scripts/validate-protocol-fixtures.ts` and exposed it via `bun run validate:protocol-fixtures:ts`.
- Updated `.codex/scripts/validate.sh` to run protocol fixture validation as part of the aggregate check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive protocol fixture validation for HTTP invalidation requests, WebSocket messages, and topic structures across server and client validation workflows.

* **Documentation**
  * Reorganized knowledge index emphasizing architecture and protocol references; clarified protocol fixture ownership and validation scope.

* **Chores**
  * Enhanced bootstrap and validation pipeline with protocol conformance checks; added shared fixture definitions as test vectors for cross-platform validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->